### PR TITLE
all socs: generate west manifests

### DIFF
--- a/all/dev.yml
+++ b/all/dev.yml
@@ -1,0 +1,112 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: next
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: next
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel:V202110.00-SMP
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel-smp
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/V202110.00-SMP
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: mcupsdk_next
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: main
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: next
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: main
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: next
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: next
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/v2024.04
+  - name: ti-pmic-lld
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld/blackbird
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: device/blackbird
+  - name: ti-pmic-lld:derby
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld/derby
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: device/derby
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/am243x/dev.yml
+++ b/am243x/dev.yml
@@ -1,0 +1,97 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: next
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: next
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: mcupsdk_next
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: main
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: next
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: main
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: next
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: next
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/v2024.04
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/am243x/main.yml
+++ b/am243x/main.yml
@@ -1,0 +1,97 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/v2024.04
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/am261x/dev.yml
+++ b/am261x/dev.yml
@@ -1,0 +1,93 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: next
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: next
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: am275x_am261x_master
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: next
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: main
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: next
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: next
+  - name: ti-pmic-lld
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld/blackbird
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: device/blackbird
+  - name: ti-pmic-lld:derby
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld/derby
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: device/derby
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/am261x/main.yml
+++ b/am261x/main.yml
@@ -1,0 +1,93 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/DEV.MCUSDK.10.00.00.09
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/DEV.MCUSDK.10.00.00.09
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/DEV.MCUSDK.10.01.00.01
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: am275x_am261x_master
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/DEV.MCUSDK.10.00.00.09
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/DEV.MCUSDK.10.00.00.09
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/DEV.MCUSDK.10.00.00.09
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/DEV.MCUSDK.10.00.00.09
+  - name: ti-pmic-lld
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld/blackbird
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: device/blackbird
+  - name: ti-pmic-lld:derby
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld/derby
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: device/derby
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/am263px/dev.yml
+++ b/am263px/dev.yml
@@ -1,0 +1,86 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: next
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: next
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: mcupsdk_next
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: next
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: main
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: next
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: next
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/v2024.04
+  - name: ti-pmic-lld
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld/blackbird
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: device/blackbird
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/am263px/main.yml
+++ b/am263px/main.yml
@@ -1,0 +1,86 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: ti-pmic-lld
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld/blackbird
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/am263x/dev.yml
+++ b/am263x/dev.yml
@@ -1,0 +1,81 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: next
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: next
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: mcupsdk_next
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: next
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: main
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: next
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: next
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/v2024.04
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/am263x/main.yml
+++ b/am263x/main.yml
@@ -1,0 +1,81 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/am273x/dev.yml
+++ b/am273x/dev.yml
@@ -1,0 +1,76 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: next
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: next
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: mcupsdk_next
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: next
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: main
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: next
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: next
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/v2024.04
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/am273x/main.yml
+++ b/am273x/main.yml
@@ -1,0 +1,76 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/am62ax/dev.yml
+++ b/am62ax/dev.yml
@@ -1,0 +1,69 @@
+manifest:
+  projects:
+  - name: mcupsdk-core-k3
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core-k3
+    revision: main
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: next
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.6.1_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel:MCUSDK_REL.09.01.00_SMP
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel-smp
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_REL.09.01.00_SMP
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-dmautils
+    path: mcu_plus_sdk/source/drivers/dmautils
+    remote: origin
+    repo-path: mcupsdk-dmautils
+    revision: main
+  - name: mcupsdk-rm-pm-hal
+    path: mcu_plus_sdk/source/drivers/device_manager/rm_pm_hal/rm_pm_hal_src
+    remote: origin
+    repo-path: mcupsdk-rm-pm-hal
+    revision: refs/tags/v09.01.08
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: mcupsdk_next
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: next
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/am62ax/main.yml
+++ b/am62ax/main.yml
@@ -1,0 +1,40 @@
+manifest:
+  projects:
+  - name: mcupsdk-core-k3
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core-k3
+    revision: refs/tags/REL.MCUSDK.09.01.00.39
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.6.1_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel:MCUSDK_REL.09.01.00_SMP
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel-smp
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_REL.09.01.00_SMP
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-dmautils
+    path: mcu_plus_sdk/source/drivers/dmautils
+    remote: origin
+    repo-path: mcupsdk-dmautils
+    revision: refs/tags/REL.MCUSDK.09.01.00.39
+  - name: mcupsdk-rm-pm-hal
+    path: mcu_plus_sdk/source/drivers/device_manager/rm_pm_hal/rm_pm_hal_src
+    remote: origin
+    repo-path: mcupsdk-rm-pm-hal
+    revision: refs/tags/v09.01.08
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/

--- a/am62px/dev.yml
+++ b/am62px/dev.yml
@@ -1,0 +1,35 @@
+manifest:
+  projects:
+  - name: mcupsdk-core-k3
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core-k3
+    revision: main
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: next
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.6.1_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-rm-pm-hal
+    path: mcu_plus_sdk/source/drivers/device_manager/rm_pm_hal/rm_pm_hal_src
+    remote: origin
+    repo-path: mcupsdk-rm-pm-hal
+    revision: refs/tags/v09.01.08
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/

--- a/am62px/main.yml
+++ b/am62px/main.yml
@@ -1,0 +1,30 @@
+manifest:
+  projects:
+  - name: mcupsdk-core-k3
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core-k3
+    revision: refs/tags/REL.MCUSDK.09.01.00.39
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.6.1_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-rm-pm-hal
+    path: mcu_plus_sdk/source/drivers/device_manager/rm_pm_hal/rm_pm_hal_src
+    remote: origin
+    repo-path: mcupsdk-rm-pm-hal
+    revision: refs/tags/v09.01.08
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/

--- a/am62x/dev.yml
+++ b/am62x/dev.yml
@@ -1,0 +1,35 @@
+manifest:
+  projects:
+  - name: mcupsdk-core-k3
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core-k3
+    revision: main
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: next
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.6.1_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-rm-pm-hal
+    path: mcu_plus_sdk/source/drivers/device_manager/rm_pm_hal/rm_pm_hal_src
+    remote: origin
+    repo-path: mcupsdk-rm-pm-hal
+    revision: refs/tags/v09.01.08
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/

--- a/am62x/main.yml
+++ b/am62x/main.yml
@@ -1,0 +1,30 @@
+manifest:
+  projects:
+  - name: mcupsdk-core-k3
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core-k3
+    revision: refs/tags/REL.MCUSDK.09.01.00.39
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.6.1_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-rm-pm-hal
+    path: mcu_plus_sdk/source/drivers/device_manager/rm_pm_hal/rm_pm_hal_src
+    remote: origin
+    repo-path: mcupsdk-rm-pm-hal
+    revision: refs/tags/v09.01.08
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/

--- a/am64x/dev.yml
+++ b/am64x/dev.yml
@@ -1,0 +1,102 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: next
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: next
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel:V202110.00-SMP
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel-smp
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/V202110.00-SMP
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: mcupsdk_next
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: main
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: next
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: main
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: next
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: next
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/v2024.04
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/am64x/main.yml
+++ b/am64x/main.yml
@@ -1,0 +1,102 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel:V202110.00-SMP
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel-smp
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/V202110.00-SMP
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/DEV.MCUSDK.10.01.00.35
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/v2024.04
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/awr294x/dev.yml
+++ b/awr294x/dev.yml
@@ -1,0 +1,59 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: next
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: next
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: mcupsdk_next
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: main
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: next
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: next
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/v2024.04
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/

--- a/awr294x/main.yml
+++ b/awr294x/main.yml
@@ -1,0 +1,59 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/DEV.MCUSDK.10.01.00.34
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/

--- a/releases/08_05_00/am243x/mcusdk.yml
+++ b/releases/08_05_00/am243x/mcusdk.yml
@@ -1,0 +1,75 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.10.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.08.05.00.24
+  - name: processor-sdk-mcu/industrial_protocol_docs
+    path: mcu_plus_sdk/docs/industrial_protocol_docs
+    remote: origin
+    repo-path: processor-sdk-mcu/industrial_protocol_docs
+    revision: refs/tags/REL.MCUSDK.08.05.00.24
+  - name: processor-sdk-mcu/mcupsdk_commercial_src_libs
+    path: mcu_plus_sdk/source/commercial
+    remote: origin
+    repo-path: processor-sdk-mcu/mcupsdk_commercial_src_libs
+    revision: refs/tags/REL.MCUSDK.08.05.00.24
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/

--- a/releases/08_05_00/am263x/mcusdk.yml
+++ b/releases/08_05_00/am263x/mcusdk.yml
@@ -1,0 +1,44 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/

--- a/releases/08_05_00/am273x/mcusdk.yml
+++ b/releases/08_05_00/am273x/mcusdk.yml
@@ -1,0 +1,44 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/

--- a/releases/08_05_00/am64x/mcusdk.yml
+++ b/releases/08_05_00/am64x/mcusdk.yml
@@ -1,0 +1,80 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel:V202110.00-SMP
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel-smp
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/V202110.00-SMP
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.10.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.08.05.00.24
+  - name: processor-sdk-mcu/industrial_protocol_docs
+    path: mcu_plus_sdk/docs/industrial_protocol_docs
+    remote: origin
+    repo-path: processor-sdk-mcu/industrial_protocol_docs
+    revision: refs/tags/REL.MCUSDK.08.05.00.24
+  - name: processor-sdk-mcu/mcupsdk_commercial_src_libs
+    path: mcu_plus_sdk/source/commercial
+    remote: origin
+    repo-path: processor-sdk-mcu/mcupsdk_commercial_src_libs
+    revision: refs/tags/REL.MCUSDK.08.05.00.24
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/

--- a/releases/08_05_00/awr294x/mcusdk.yml
+++ b/releases/08_05_00/awr294x/mcusdk.yml
@@ -1,0 +1,51 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: processor-sdk-mcu/safertos
+    path: mcu_plus_sdk/source/kernel/safertos/safeRTOS
+    remote: comm
+    repo-path: processor-sdk-mcu/safertos
+    revision: master
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.08.05.00.25
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/

--- a/releases/08_06_00/am243x/mcusdk.yml
+++ b/releases/08_06_00/am243x/mcusdk.yml
@@ -1,0 +1,82 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: processor-sdk-mcu/industrial_protocol_docs
+    path: mcu_plus_sdk/docs/industrial_protocol_docs
+    remote: comm
+    repo-path: processor-sdk-mcu/industrial_protocol_docs
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: processor-sdk-mcu/mcupsdk_commercial_src_libs
+    path: mcu_plus_sdk/source/commercial
+    remote: comm
+    repo-path: processor-sdk-mcu/mcupsdk_commercial_src_libs
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/08_06_00/am263x/mcusdk.yml
+++ b/releases/08_06_00/am263x/mcusdk.yml
@@ -1,0 +1,56 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/08_06_00/am273x/mcusdk.yml
+++ b/releases/08_06_00/am273x/mcusdk.yml
@@ -1,0 +1,51 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/08_06_00/am64x/mcusdk.yml
+++ b/releases/08_06_00/am64x/mcusdk.yml
@@ -1,0 +1,87 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel:V202110.00-SMP
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel-smp
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/V202110.00-SMP
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: processor-sdk-mcu/industrial_protocol_docs
+    path: mcu_plus_sdk/docs/industrial_protocol_docs
+    remote: comm
+    repo-path: processor-sdk-mcu/industrial_protocol_docs
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: processor-sdk-mcu/mcupsdk_commercial_src_libs
+    path: mcu_plus_sdk/source/commercial
+    remote: comm
+    repo-path: processor-sdk-mcu/mcupsdk_commercial_src_libs
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/08_06_00/awr294x/mcusdk.yml
+++ b/releases/08_06_00/awr294x/mcusdk.yml
@@ -1,0 +1,51 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: processor-sdk-mcu/safertos
+    path: mcu_plus_sdk/source/kernel/safertos/safeRTOS
+    remote: comm
+    repo-path: processor-sdk-mcu/safertos
+    revision: master
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.08.06.00.46
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/

--- a/releases/09_00_00/am243x/mcusdk.yml
+++ b/releases/09_00_00/am243x/mcusdk.yml
@@ -1,0 +1,77 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_00_00/am263x/mcusdk.yml
+++ b/releases/09_00_00/am263x/mcusdk.yml
@@ -1,0 +1,56 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_00_00/am273x/mcusdk.yml
+++ b/releases/09_00_00/am273x/mcusdk.yml
@@ -1,0 +1,51 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_00_00/am64x/mcusdk.yml
+++ b/releases/09_00_00/am64x/mcusdk.yml
@@ -1,0 +1,82 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel:V202110.00-SMP
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel-smp
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/V202110.00-SMP
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_00_00/awr294x/mcusdk.yml
+++ b/releases/09_00_00/awr294x/mcusdk.yml
@@ -1,0 +1,51 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: processor-sdk-mcu/safertos
+    path: mcu_plus_sdk/source/kernel/safertos/safeRTOS
+    remote: comm
+    repo-path: processor-sdk-mcu/safertos
+    revision: master
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.00.00.35
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/

--- a/releases/09_00_01/am263px/mcusdk.yml
+++ b/releases/09_00_01/am263px/mcusdk.yml
@@ -1,0 +1,56 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.00.01.13
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.00.01.13
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.00.01.13
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_1_2_RELEASE
+  - name: lwip/lwip-contrib
+    path: mcu_plus_sdk/source/networking/lwip/lwip-contrib
+    remote: lwip
+    repo-path: lwip/lwip-contrib
+    revision: refs/tags/STABLE-2_1_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_01_00/am243x/mcusdk.yml
+++ b/releases/09_01_00/am243x/mcusdk.yml
@@ -1,0 +1,72 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_01_00/am263px/mcusdk.yml
+++ b/releases/09_01_00/am263px/mcusdk.yml
@@ -1,0 +1,51 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_01_00/am263x/mcusdk.yml
+++ b/releases/09_01_00/am263x/mcusdk.yml
@@ -1,0 +1,56 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_01_00/am273x/mcusdk.yml
+++ b/releases/09_01_00/am273x/mcusdk.yml
@@ -1,0 +1,51 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_01_00/am64x/mcusdk.yml
+++ b/releases/09_01_00/am64x/mcusdk.yml
@@ -1,0 +1,77 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel:V202110.00-SMP
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel-smp
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/V202110.00-SMP
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_01_00/awr294x/mcusdk.yml
+++ b/releases/09_01_00/awr294x/mcusdk.yml
@@ -1,0 +1,46 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: processor-sdk-mcu/safertos
+    path: mcu_plus_sdk/source/kernel/safertos/safeRTOS
+    remote: comm
+    repo-path: processor-sdk-mcu/safertos
+    revision: master
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.01.00.42
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/

--- a/releases/09_02_00/am243x/mcusdk.yml
+++ b/releases/09_02_00/am243x/mcusdk.yml
@@ -1,0 +1,72 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_02_00/am263px/mcusdk.yml
+++ b/releases/09_02_00/am263px/mcusdk.yml
@@ -1,0 +1,56 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_02_00/am263x/mcusdk.yml
+++ b/releases/09_02_00/am263x/mcusdk.yml
@@ -1,0 +1,56 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_02_00/am273x/mcusdk.yml
+++ b/releases/09_02_00/am273x/mcusdk.yml
@@ -1,0 +1,51 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.02.00.60
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.02.00.60
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.02.00.60
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.02.00.60
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_02_00/am64x/mcusdk.yml
+++ b/releases/09_02_00/am64x/mcusdk.yml
@@ -1,0 +1,77 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel:V202110.00-SMP
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel-smp
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/V202110.00-SMP
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_02_00/awr294x/mcusdk.yml
+++ b/releases/09_02_00/awr294x/mcusdk.yml
@@ -1,0 +1,46 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: processor-sdk-mcu/safertos
+    path: mcu_plus_sdk/source/kernel/safertos/safeRTOS
+    remote: comm
+    repo-path: processor-sdk-mcu/safertos
+    revision: master
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.02.00.56
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/

--- a/releases/09_02_01/am243x/mcusdk.yml
+++ b/releases/09_02_01/am243x/mcusdk.yml
@@ -1,0 +1,72 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_02_01/am263px/mcusdk.yml
+++ b/releases/09_02_01/am263px/mcusdk.yml
@@ -1,0 +1,56 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_02_01/am263x/mcusdk.yml
+++ b/releases/09_02_01/am263x/mcusdk.yml
@@ -1,0 +1,56 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_02_01/am273x/mcusdk.yml
+++ b/releases/09_02_01/am273x/mcusdk.yml
@@ -1,0 +1,51 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_02_01/am64x/mcusdk.yml
+++ b/releases/09_02_01/am64x/mcusdk.yml
@@ -1,0 +1,77 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel:V202110.00-SMP
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel-smp
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/V202110.00-SMP
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/09_02_01/awr294x/mcusdk.yml
+++ b/releases/09_02_01/awr294x/mcusdk.yml
@@ -1,0 +1,46 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: processor-sdk-mcu/safertos
+    path: mcu_plus_sdk/source/kernel/safertos/safeRTOS
+    remote: comm
+    repo-path: processor-sdk-mcu/safertos
+    revision: master
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.09.02.01.06
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/

--- a/releases/10_00_00/am243x/mcusdk.yml
+++ b/releases/10_00_00/am243x/mcusdk.yml
@@ -1,0 +1,92 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/10_00_00/am261x/mcusdk.yml
+++ b/releases/10_00_00/am261x/mcusdk.yml
@@ -1,0 +1,78 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/10_00_00/am263px/mcusdk.yml
+++ b/releases/10_00_00/am263px/mcusdk.yml
@@ -1,0 +1,81 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: ti-pmic-lld
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: device/blackbird
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/10_00_00/am263x/mcusdk.yml
+++ b/releases/10_00_00/am263x/mcusdk.yml
@@ -1,0 +1,76 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/10_00_00/am273x/mcusdk.yml
+++ b/releases/10_00_00/am273x/mcusdk.yml
@@ -1,0 +1,66 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/10_00_00/am64x/mcusdk.yml
+++ b/releases/10_00_00/am64x/mcusdk.yml
@@ -1,0 +1,97 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel:V202110.00-SMP
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel-smp
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/V202110.00-SMP
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/10_00_00/awr294x/mcusdk.yml
+++ b/releases/10_00_00/awr294x/mcusdk.yml
@@ -1,0 +1,54 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V10.4.3_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.00.00.37
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/

--- a/releases/10_00_01/am261x/mcusdk.yml
+++ b/releases/10_00_01/am261x/mcusdk.yml
@@ -1,0 +1,93 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.10.00.01.10
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.00.01.10
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.10.00.01.10
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.10.00.01.10
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/REL.MCUSDK.10.00.01.10
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.10.00.01.10
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.00.01.10
+  - name: ti-pmic-lld
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld/blackbird
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: device/blackbird
+  - name: ti-pmic-lld:derby
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld/derby
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: device/derby
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/10_01_00/am243x/mcusdk.yml
+++ b/releases/10_01_00/am243x/mcusdk.yml
@@ -1,0 +1,97 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/v2024.04
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/10_01_00/am243x/mcusdk_threadx.yml
+++ b/releases/10_01_00/am243x/mcusdk_threadx.yml
@@ -1,0 +1,114 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.THREADX.10.01.00.02
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.01.00.30
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.THREADX.10.01.00.02
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.10.01.00.30
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.10.01.00.30
+  - name: ti-ethernet-software
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ti-ethernet-software
+    revision: refs/tags/v2024.04
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.THREADX.10.01.00.02
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.01.00.30
+  - name: threadx
+    path: mcu_plus_sdk/source/kernel/threadx/threadx_src
+    remote: threadx
+    repo-path: threadx
+    revision: refs/tags/v6.4.1_rel
+  - name: filex
+    path: mcu_plus_sdk/source/fs/filex/filex_src
+    remote: threadx
+    repo-path: filex
+    revision: refs/tags/v6.4.1_rel
+  - name: levelx
+    path: mcu_plus_sdk/source/fs/filex/levelx_src
+    remote: threadx
+    repo-path: levelx
+    revision: refs/tags/v6.4.1_rel
+  - name: netxduo
+    path: mcu_plus_sdk/source/networking/netxduo/netxduo_src
+    remote: threadx
+    repo-path: netxduo
+    revision: refs/tags/v6.4.1_rel
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: https://git.savannah.gnu.org/git/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/
+  - name: threadx
+    url-base: https://github.com/eclipse-threadx/

--- a/releases/10_01_00/am261x/mcusdk.yml
+++ b/releases/10_01_00/am261x/mcusdk.yml
@@ -1,0 +1,93 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: ti-pmic-lld
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld/blackbird
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: device/blackbird
+  - name: ti-pmic-lld:derby
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld/derby
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: device/derby
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/10_01_00/am263px/mcusdk.yml
+++ b/releases/10_01_00/am263px/mcusdk.yml
@@ -1,0 +1,86 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: ti-pmic-lld
+    path: mcu_plus_sdk/source/board/pmic/pmic_lld/blackbird
+    remote: origin
+    repo-path: ti-pmic-lld
+    revision: device/blackbird
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/10_01_00/am263x/mcusdk.yml
+++ b/releases/10_01_00/am263x/mcusdk.yml
@@ -1,0 +1,81 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  remotes:
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/

--- a/releases/10_01_00/am64x/mcusdk.yml
+++ b/releases/10_01_00/am64x/mcusdk.yml
@@ -1,0 +1,102 @@
+manifest:
+  projects:
+  - name: mcupsdk-core
+    path: mcu_plus_sdk
+    remote: origin
+    repo-path: mcupsdk-core
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-setup
+    path: mcupsdk_setup
+    remote: origin
+    repo-path: mcupsdk-setup
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-FreeRTOS-Kernel
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/MCUSDK_V11.1.0_MAIN
+  - name: mcupsdk-FreeRTOS-Kernel:V202110.00-SMP
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel-smp
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Kernel
+    revision: refs/tags/V202110.00-SMP
+  - name: mcupsdk-FreeRTOS-Posix
+    path: mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-Posix
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-enet-lld
+    path: mcu_plus_sdk/source/networking/enet/core
+    remote: origin
+    repo-path: mcupsdk-enet-lld
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-FreeRTOS-FAT
+    path: mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT
+    remote: origin
+    repo-path: mcupsdk-FreeRTOS-FAT
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: mcupsdk-littlefs
+    path: mcu_plus_sdk/source/fs/littlefs/LittleFS
+    remote: origin
+    repo-path: mcupsdk-littlefs
+    revision: refs/tags/MCUSDK_V1.0.0_MAIN
+  - name: lwip
+    path: mcu_plus_sdk/source/networking/lwip/lwip-stack
+    remote: lwip
+    repo-path: lwip
+    revision: refs/tags/STABLE-2_2_0_RELEASE
+  - name: tinyusb
+    path: mcu_plus_sdk/source/usb/tinyusb/tinyusb-stack
+    remote: tinyusb
+    repo-path: tinyusb
+    revision: refs/tags/0.14.0
+  - name: mcupsdk-cmsis
+    path: mcu_plus_sdk/source/cmsis
+    remote: origin
+    repo-path: mcupsdk-cmsis
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mbedtls
+    path: mcu_plus_sdk/source/networking/mbedtls_library/mbedtls
+    remote: mbedtls
+    repo-path: mbedtls
+    revision: refs/tags/mbedtls-2.13.1
+  - name: enet-tsn-stack
+    path: mcu_plus_sdk/source/networking/tsn/tsn-stack
+    remote: origin
+    repo-path: enet-tsn-stack
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: multicore-elf
+    path: mcu_plus_sdk/tools/boot/multicore-elf
+    remote: origin
+    repo-path: multicore-elf
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: mcupsdk-sysconfig
+    path: mcu_plus_sdk/source/sysconfig
+    remote: origin
+    repo-path: mcupsdk-sysconfig
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: tifs-mcu-common
+    path: mcu_plus_sdk/source/security/security_common
+    remote: origin
+    repo-path: tifs-mcu-common
+    revision: refs/tags/REL.MCUSDK.10.01.00.33
+  - name: ethernet-rtos-drivers
+    path: mcu_plus_sdk/source/board/ethphy/enet
+    remote: origin
+    repo-path: ethernet-rtos-drivers
+    revision: refs/tags/v2024.04
+  remotes:
+  - name: comm
+    url-base: ssh://git@bitbucket.itg.ti.com/
+  - name: origin
+    url-base: https://github.com/TexasInstruments/
+  - name: freertos
+    url-base: https://github.com/FreeRTOS/
+  - name: lwip
+    url-base: git://git.savannah.gnu.org/
+  - name: tinyusb
+    url-base: https://github.com/hathach/
+  - name: armmbed
+    url-base: https://github.com/ARMmbed/
+  - name: mbedtls
+    url-base: https://github.com/Mbed-TLS/


### PR DESCRIPTION
Manifests for west, inspired by the `mcupsdk_west` branch but based on current `main`.

All files in this patchset are generated by a small script I wrote [here](https://gist.github.com/natto1784/c6ceb2efeaf3f8ce12f811af8c229923) that converts repo manifests to west manifests. Can use the following command for running it recursively:
```
find . -type f -name "*xml" | while IFS= read -r file; do echo $file; ~/repotowest.py "$file" "${file%.xml}.yml"; done
```

The reason I didn't rebase the `mcupsdk_west` branch and add the changes was to avoid clutter in this PR. Feel free to suggest changes or create a new branch for merge.