### PR TITLE
Update manifest for AM62AX ThreadX branch

### DIFF
--- a/am62ax/dev.xml
+++ b/am62ax/dev.xml
@@ -5,11 +5,11 @@
    <remote fetch="https://github.com/Mbed-TLS/"     name="mbedtls"/>
    <remote fetch="https://github.com/eclipse-threadx/" name="threadx"/>
    <project remote="origin"   path="mcu_plus_sdk"                                               name="mcupsdk-core-k3"           revision="am62a_threadx"/>
-   <project remote="origin"   path="mcupsdk_setup"                                              name="mcupsdk-setup"             revision="k3_main"/>
+   <project remote="origin"   path="mcupsdk_setup"                                              name="mcupsdk-setup"             revision="refs/tags/DEV.MCUSDK.K3.10.01.00.11"/>
    <project remote="origin"   path="mcu_plus_sdk/source/kernel/freertos/FreeRTOS-Kernel"        name="mcupsdk-FreeRTOS-Kernel"   revision="refs/tags/V11.1.0"/>
    <project remote="origin"   path="mcu_plus_sdk/source/kernel/freertos/FreeRTOS-POSIX"         name="mcupsdk-FreeRTOS-Posix"    revision="refs/tags/MCUSDK_V1.0.0_MAIN"/>
    <project remote="origin"   path="mcu_plus_sdk/source/fs/freertos_fat/FreeRTOS-FAT"           name="mcupsdk-FreeRTOS-FAT"      revision="refs/tags/MCUSDK_V1.1.0_MAIN"/>
-   <project remote="origin"   path="mcu_plus_sdk/source/drivers/dmautils"                       name="mcupsdk-dmautils"          revision="master"/>   
+   <project remote="origin"   path="mcu_plus_sdk/source/drivers/dmautils"                       name="mcupsdk-dmautils"          revision="refs/tags/REL.MCUSDK.K3.10.01.00.35"/>   
    <project remote="origin"   path="mcu_plus_sdk/source/drivers/device_manager/rm_pm_hal/rm_pm_hal_src" name="mcupsdk-rm-pm-hal" revision="refs/tags/v10.01.01"/>
    <project remote="origin"   path="mcu_plus_sdk/source/networking/enet/core"                   name="mcupsdk-enet-lld"          revision="am62a_threadx"/>
    <project remote="origin"   path="mcu_plus_sdk/source/networking/tsn/tsn-stack"               name="enet-tsn-stack"            revision="next"/>


### PR DESCRIPTION
Change revision for the sub-repos mcupsdk-setup, enet-tsn-stack and dmautils to match the requirements of the AM62AX-ThreadX branch.